### PR TITLE
Update view.js

### DIFF
--- a/src/Resources/lsjs-app/modules/merconis/putInCartForm/putInCartFormInstance/view.js
+++ b/src/Resources/lsjs-app/modules/merconis/putInCartForm/putInCartFormInstance/view.js
@@ -56,6 +56,10 @@ var obj_classdef = 	{
 
 				onComplete: function() {
 					lsjs.loadingIndicator.__controller.hide();
+				},
+
+				onSuccess: function(els, str_html, str_script) {
+					Browser.exec(str_script);
 				}
 			}).send();
 		});


### PR DESCRIPTION
Diese Änderung wird vor allem im Zusammenhang mit Merconis 4 benötigt, um sicherzustellen, dass in dem auf jeder Seite vorhandenen Checkout-Bereich beim Cajax-Reload auch JavaScripts, wie z. B. das Script für PayPal Checkout, ausgeführt werden. Das PayPal-Checkout-Interface würde ansonsten nicht mehr funktionieren, nachdem man etwas in den Warenkorb gelegt hat, wenn es zuvor im Checkout bereits ausgewählt war.

Ob in Merconis ab Version 5 überhaupt Bedarf für diese Änderung besteht, ist unklar, da es beim "In den Warenkorb legen" keinen Cajax-Reload des Checkouts/der Zahlungsoptionsauswahl mehr gibt. Es ist aber durchaus denkbar, dass es irgendwann auch in neueren Merconis-Versionen Situationen geben wird, in denen aus evtl. ganz anderen Gründen das Ausführen von nachgeladenem JavaScript notwendig ist. Deshalb von mir der Vorschlag, das auch hier einzubauen.