### PR TITLE
Improve insert tag "shopPicture"

### DIFF
--- a/src/Resources/contao/classes/ls_shop_customInserttags.php
+++ b/src/Resources/contao/classes/ls_shop_customInserttags.php
@@ -147,13 +147,16 @@ class ls_shop_customInserttags
                         switch ($key)
                         {
                             case 'size':
+                                /*
+                                 * Determine the image size id with the given merconis_alias and replace the alias with
+                                 * the id in the parameter string or remove the size parameter entirely if no image size
+                                 * record could be found with the merconis_alias.
+                                 */
                                 $result = \Database::getInstance()->prepare("SELECT id FROM tl_image_size WHERE merconis_alias=?")->execute($value)->fetchAssoc();
-                                if($result){
-                                    //replace text with id
-                                    $params = str_replace('size='.$value, 'size='.$result['id'], $params);
-                                }else{
-                                    //if no if can be found remove size
-                                    $params = str_replace('size='.$value, '', $params);
+                                if ($result) {
+                                    $params = str_replace('size=' . $value, 'size=' . $result['id'], $params);
+                                } else {
+                                    $params = ls_shop_generalHelper::removeGetParametersFromUrl($params, 'size');
                                 }
                                 break;
                         }


### PR DESCRIPTION
If the size parameter is present in the shopPicture insert tag but there's no image size record with the specified alias, the size parameter gets removed from the parameter string. After removing the size parameter the parameter string could sometimes contain leftover "?" or "&" characters that could later lead to a warning when Contao rendered the picture insert tag with the incorrect parameter string.