### PR TITLE
Use Contao hook "modifyFrontendPage" instead of "outputFrontendTempla…

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -73,7 +73,7 @@ $GLOBALS['TL_HOOKS']['getArticle'][] = array('Merconis\Core\ls_shop_generalHelpe
  */
 $GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = array('Merconis\Core\ls_shop_filterController', 'generateAndInsertFilterForms');
 
-$GLOBALS['TL_HOOKS']['outputFrontendTemplate'][] = array('Merconis\Core\ls_shop_generalHelper', 'callback_outputFrontendTemplate');
+$GLOBALS['TL_HOOKS']['modifyFrontendPage'][] = array('Merconis\Core\ls_shop_generalHelper', 'callback_modifyFrontendPage');
 
 /*
  * Hook for the multiLanguage DCA manipulation

--- a/src/Resources/contao/helpers/ls_shop_generalHelper.php
+++ b/src/Resources/contao/helpers/ls_shop_generalHelper.php
@@ -4265,7 +4265,7 @@ class ls_shop_generalHelper
         return $GLOBALS['merconis_globals']['messageSent'][$identificationToken];
     }
 
-    public static function callback_outputFrontendTemplate($strContent, $strTemplate)
+    public static function callback_modifyFrontendPage($strContent, $strTemplate)
     {
         /*
          * The contao hook has to call this intermediary function because the hook requires the content to be


### PR DESCRIPTION
…te" to trigger ls_shop_msg::decreaseLifetime() when the insert tags are already replaced and thereby allow story telling insert tags to work as expected in situations where they display an add-to-cart button.