### PR TITLE
Suggest fix m5.1 price sorting overview

### DIFF
--- a/src/Resources/contao/classes/ls_shop_product.php
+++ b/src/Resources/contao/classes/ls_shop_product.php
@@ -1217,7 +1217,7 @@ returns the product price or the cheapest variant price.
                     }
                 }
 
-                return array($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison);
+                return array($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison, $float_cheapestPrice);
                 break;
 
 			case '_priceMinimumAfterTax':

--- a/src/Resources/contao/classes/ls_shop_product.php
+++ b/src/Resources/contao/classes/ls_shop_product.php
@@ -63,6 +63,8 @@ class ls_shop_product
     // Holds image galleries created with getImageGallery()
     protected $arr_imageGalleries = [];
 
+    private ?array $arr_scaledOrVariantsPriceMinimum = null;
+
     public function __construct($intID = false, $configuratorHash = '') {
 		$this->ls_ID = $intID;
 
@@ -1177,6 +1179,30 @@ returns the product price or the cheapest variant price.
                 }
 				break;
 
+
+
+
+            case '_cheapestPriceComesFromScalePrices':
+		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+		return $bln_cheapestPriceComesFromScalePrices;
+
+            case '_cheapestPriceOutput':
+		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+		return $str_cheapestPriceOutput;
+
+            case '_minQuantityInfo':
+		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+		return $str_minQuantityInfo;
+
+            case '_cheapestPriceQuantityComparison':
+		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+		return $str_cheapestPriceQuantityComparison;
+
+
+
+
+
+
             case '_scaledOrVariantsPriceMinimum'
                 /* ## DESCRIPTION:
                  * The logic that previously ran in 2 templates has been moved here
@@ -1185,39 +1211,41 @@ returns the product price or the cheapest variant price.
                  * All variants are looped through - if available - and then all scaled prices - if available.
                  */
                 :
+		if ($this->arr_scaledOrVariantsPriceMinimum === null) {
+	                $float_cheapestPrice = null;
+	                $str_cheapestPriceOutput = null;
+	                $str_minQuantityInfo = null;
+	                $bln_cheapestPriceComesFromScalePrices = false;
+	                $str_cheapestPriceQuantityComparison = null;
 
-                $float_cheapestPrice = null;
-                $str_cheapestPriceOutput = null;
-                $str_minQuantityInfo = null;
-                $bln_cheapestPriceComesFromScalePrices = false;
-                $str_cheapestPriceQuantityComparison = null;
+	                if ($this->_hasVariants) {
+	                    foreach ($this->_variants as $obj_variant){
+	                        if (is_array($obj_variant->_scalePricesOutputUnconfigured)) {
+	                            $this->getMinScalePrice($obj_variant->_scalePricesOutputUnconfigured,$float_cheapestPrice, $str_cheapestPriceOutput, $str_minQuantityInfo, $bln_cheapestPriceComesFromScalePrices);
+	                            $str_cheapestPriceQuantityComparison = $obj_variant->_getQuantityComparisonText($float_cheapestPrice);
+	                        } else {
+	                            if (!$float_cheapestPrice || $obj_variant->_priceAfterTax < $float_cheapestPrice) {
+	                                $float_cheapestPrice = $obj_variant->_priceAfterTax;
+	                                $str_cheapestPriceOutput = ls_shop_generalHelper::outputPrice($float_cheapestPrice);
+	                                $str_cheapestPriceQuantityComparison = $obj_variant->_getQuantityComparisonText('_priceAfterTax');
+	                            }
+	                        }
+	                    }
+	                } else {
+	                    if (is_array($this->_scalePricesOutputUnconfigured)) {
+	                        $this->getMinScalePrice($this->_scalePricesOutputUnconfigured,$float_cheapestPrice, $str_cheapestPriceOutput, $str_minQuantityInfo, $bln_cheapestPriceComesFromScalePrices);
+	                        $str_cheapestPriceQuantityComparison = $this->_getQuantityComparisonText($float_cheapestPrice);
+	                    } else {
+	                        // quantity comparison for products without variants and scale prices
+	                        $float_cheapestPrice = $this->_priceAfterTax;
+	                        $str_cheapestPriceOutput = ls_shop_generalHelper::outputPrice($float_cheapestPrice);
+	                        $str_cheapestPriceQuantityComparison = $this->_getQuantityComparisonText('_priceAfterTax');
+	                    }
+	                }
 
-                if ($this->_hasVariants) {
-                    foreach ($this->_variants as $obj_variant){
-                        if (is_array($obj_variant->_scalePricesOutputUnconfigured)) {
-                            $this->getMinScalePrice($obj_variant->_scalePricesOutputUnconfigured,$float_cheapestPrice, $str_cheapestPriceOutput, $str_minQuantityInfo, $bln_cheapestPriceComesFromScalePrices);
-                            $str_cheapestPriceQuantityComparison = $obj_variant->_getQuantityComparisonText($float_cheapestPrice);
-                        } else {
-                            if (!$float_cheapestPrice || $obj_variant->_priceAfterTax < $float_cheapestPrice) {
-                                $float_cheapestPrice = $obj_variant->_priceAfterTax;
-                                $str_cheapestPriceOutput = ls_shop_generalHelper::outputPrice($float_cheapestPrice);
-                                $str_cheapestPriceQuantityComparison = $obj_variant->_getQuantityComparisonText('_priceAfterTax');
-                            }
-                        }
-                    }
-                } else {
-                    if (is_array($this->_scalePricesOutputUnconfigured)) {
-                        $this->getMinScalePrice($this->_scalePricesOutputUnconfigured,$float_cheapestPrice, $str_cheapestPriceOutput, $str_minQuantityInfo, $bln_cheapestPriceComesFromScalePrices);
-                        $str_cheapestPriceQuantityComparison = $this->_getQuantityComparisonText($float_cheapestPrice);
-                    } else {
-                        // quantity comparison for products without variants and scale prices
-                        $float_cheapestPrice = $this->_priceAfterTax;
-                        $str_cheapestPriceOutput = ls_shop_generalHelper::outputPrice($float_cheapestPrice);
-                        $str_cheapestPriceQuantityComparison = $this->_getQuantityComparisonText('_priceAfterTax');
-                    }
-                }
-
-                return array($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison, $float_cheapestPrice);
+	                $this->arr_scaledOrVariantsPriceMinimum = array($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison);
+		}
+		return $this->arr_scaledOrVariantsPriceMinimum;
                 break;
 
 			case '_priceMinimumAfterTax':

--- a/src/Resources/contao/classes/ls_shop_product.php
+++ b/src/Resources/contao/classes/ls_shop_product.php
@@ -1179,29 +1179,31 @@ returns the product price or the cheapest variant price.
                 }
 				break;
 
-
-
-
+                /*
+                 * @toDo rework suggest
+                 */
             case '_cheapestPriceComesFromScalePrices':
-		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
-		return $bln_cheapestPriceComesFromScalePrices;
-
+		        list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+		        return $bln_cheapestPriceComesFromScalePrices;
+			
             case '_cheapestPriceOutput':
-		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
-		return $str_cheapestPriceOutput;
-
+                list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+                return $str_cheapestPriceOutput;
+			
             case '_minQuantityInfo':
-		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
-		return $str_minQuantityInfo;
-
+                list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+                return $str_minQuantityInfo;
+			
             case '_cheapestPriceQuantityComparison':
-		list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
-		return $str_cheapestPriceQuantityComparison;
+                list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+                return $str_cheapestPriceQuantityComparison;
 
-
-
-
-
+            case '_cheapestPriceRaw':
+                list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison, $float_cheapestPrice) = $this->objProduct->_scaledOrVariantsPriceMinimum;
+                return $float_cheapestPrice;
+                /*
+                 * end @toDo
+                 */
 
             case '_scaledOrVariantsPriceMinimum'
                 /* ## DESCRIPTION:
@@ -1217,7 +1219,7 @@ returns the product price or the cheapest variant price.
 	                $str_minQuantityInfo = null;
 	                $bln_cheapestPriceComesFromScalePrices = false;
 	                $str_cheapestPriceQuantityComparison = null;
-
+	
 	                if ($this->_hasVariants) {
 	                    foreach ($this->_variants as $obj_variant){
 	                        if (is_array($obj_variant->_scalePricesOutputUnconfigured)) {
@@ -1242,8 +1244,8 @@ returns the product price or the cheapest variant price.
 	                        $str_cheapestPriceQuantityComparison = $this->_getQuantityComparisonText('_priceAfterTax');
 	                    }
 	                }
-
-	                $this->arr_scaledOrVariantsPriceMinimum = array($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison);
+	
+	                $this->arr_scaledOrVariantsPriceMinimum = array($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison, $float_cheapestPrice);
 		}
 		return $this->arr_scaledOrVariantsPriceMinimum;
                 break;

--- a/src/Resources/contao/classes/ls_shop_productSearcher.php
+++ b/src/Resources/contao/classes/ls_shop_productSearcher.php
@@ -2095,18 +2095,17 @@ class ls_shop_productSearcher
                     $sortingTypeFlag = SORT_NUMERIC;
                     foreach ($arrProductsAfterFilter as $k => $arrProduct) {
                         /*
-                         * If the displayPrice already exists because it has been
-                         * calculated before for the filter, we use it.
-                         * If not, we calculate it now.
+                         * Calculates the cheapest price for this product, checks variants and scale prices
                          */
-                        if (isset($arrProduct['price'])) {
-                            $arrOrder[$k] = $arrProduct['price'];
-                        } else {
-                            if ($this->bln_useGroupPrices) {
-                                $arrProduct = $this->updateProductRowWithGroupPrice($arrProduct);
-                            }
 
-                            $arrOrder[$k] = ls_shop_generalHelper::getDisplayPrice($arrProduct['lsShopProductPrice'], $arrProduct['lsShopProductSteuersatz']);
+                        $objProduct = ls_shop_generalHelper::getObjProduct($arrProduct['id']);
+
+                        list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $objProduct->_scaledOrVariantsPriceMinimum;
+
+                        if (!$bln_cheapestPriceComesFromScalePrices) {
+                            $arrOrder[$k] = $objProduct->_unscaledPriceMinimumAfterTaxFormatted;
+                        } else {
+                            $arrOrder[$k] = $str_cheapestPriceOutput;
                         }
 
                         $arr_tmpProductsToSort[$k] = $arrProduct;

--- a/src/Resources/contao/classes/ls_shop_productSearcher.php
+++ b/src/Resources/contao/classes/ls_shop_productSearcher.php
@@ -2100,12 +2100,12 @@ class ls_shop_productSearcher
 
                         $objProduct = ls_shop_generalHelper::getObjProduct($arrProduct['id']);
 
-                        list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $objProduct->_scaledOrVariantsPriceMinimum;
+                        list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison, $float_cheapestPrice) = $objProduct->_scaledOrVariantsPriceMinimum;
 
                         if (!$bln_cheapestPriceComesFromScalePrices) {
-                            $arrOrder[$k] = $objProduct->_unscaledPriceMinimumAfterTaxFormatted;
+                            $arrOrder[$k] = $objProduct->_unscaledPriceMinimumAfterTax;
                         } else {
-                            $arrOrder[$k] = $str_cheapestPriceOutput;
+                            $arrOrder[$k] = $float_cheapestPrice;
                         }
 
                         $arr_tmpProductsToSort[$k] = $arrProduct;

--- a/src/Resources/contao/templates/template_productOverview_01.html5
+++ b/src/Resources/contao/templates/template_productOverview_01.html5
@@ -114,14 +114,12 @@
 					<span class="currentPrice<?php echo $this->objProduct->_isOnSale ? ' isOnSale' : ''; ?>">
                         <?php
 
-                        list($bln_cheapestPriceComesFromScalePrices, $str_cheapestPriceOutput, $str_minQuantityInfo, $str_cheapestPriceQuantityComparison) = $this->objProduct->_scaledOrVariantsPriceMinimum;
-
-                        if (!$bln_cheapestPriceComesFromScalePrices) {
+                        if (!$this->objProduct->_cheapestPriceComesFromScalePrices) {
                             // Standard-Ausgabe
                             if ($this->objProduct->_unscaledPricesAreDifferent) { ?><?php echo $GLOBALS['TL_LANG']['MSC']['ls_shop']['misc']['from']; ?> <?php } ?><?php echo $this->objProduct->_unscaledPriceMinimumAfterTaxFormatted; ?><?php if ($this->objProduct->_hasQuantityUnit) { ?>/<?php echo $this->objProduct->_quantityUnit; ?><?php }
                         } else {
                             ?>
-                            <?= $GLOBALS['TL_LANG']['MSC']['ls_shop']['misc']['from'] ?> <?= $str_cheapestPriceOutput ?><?php if ($this->objProduct->_hasQuantityUnit) { ?>/<?php echo $this->objProduct->_quantityUnit; ?><?php } ?><?php echo $str_minQuantityInfo ? '<span class="min-quantity-info"> ('.$str_minQuantityInfo.')</span>' : ''; ?>
+                            <?= $GLOBALS['TL_LANG']['MSC']['ls_shop']['misc']['from'] ?> <?= $this->objProduct->_cheapestPriceOutput ?><?php if ($this->objProduct->_hasQuantityUnit) { ?>/<?php echo $this->objProduct->_quantityUnit; ?><?php } ?><?php echo $this->objProduct->_minQuantityInfo ? '<span class="min-quantity-info"> ('.$this->objProduct->_minQuantityInfo.')</span>' : ''; ?>
                             <?php
                         }
                         ?>
@@ -136,9 +134,9 @@
 					<?php } ?>
 				<?php // <- ##### OLD PRICE ##### ?>
                 <?php // ##### QUANTITY COMPARISON ##### -> ?>
-                <?php if($str_cheapestPriceQuantityComparison) { ?>
+                <?php if($this->objProduct->_cheapestPriceQuantityComparison) { ?>
                 <div class="quantityComparison">
-                    <?php echo $str_cheapestPriceQuantityComparison; ?>
+                    <?php echo $this->objProduct->_cheapestPriceQuantityComparison; ?>
                 </div>
                 <?php } ?>
                 <?php // <- ##### QUANTITY COMPARISON ##### -> ?>


### PR DESCRIPTION
@chiron501 Wie besprochen, hier mein schneller Entwurf für eine verbesserte Zugriffsmöglichkeit auf die Einzelinfos aus _scaledOrVariantsPriceMinimum

Anders als ich es vorhin gesagt hatte, würde ich eher _scaledOrVariantsPriceMinimum weiterhin erhalten, statt es aus __get in eine normale Funktion zu übertragen. So vermeiden wir einen BC-Break.

Und das Caching macht in diesem Fall keinen Sinn über eine globale Variable, weil das Produkt-Objekt ja "persistent" ist innerhalb einer Skript-Laufzeit und man deshalb am einfachsten das ermittelte Ergebnis in einen class member schreiben kann.